### PR TITLE
Fix Firefox selections

### DIFF
--- a/src/converters/md.js
+++ b/src/converters/md.js
@@ -815,11 +815,13 @@ function convertA(ctx, el) {
     href = absolutize(href, ctx.locationHref);
     href = mdEncodeUri(href);
 
-    const text = convertNodes(ctx, el.childNodes).trim().replaceAll('\n', ' ');
+    let text = convertNodes(ctx, el.childNodes).trim().replaceAll('\n', ' ');
     if (!text) {
         return '';
     } else if (!href) {
         return text;
+    } else if (text.startsWith('^')) {
+        text = '\\^' + text.slice(1);
     }
 
     const title = ctx.escape(el.getAttribute('title') || '').replaceAll('"', '\\"');

--- a/src/options.html
+++ b/src/options.html
@@ -46,16 +46,16 @@ as the options page. -->
       <a href="https://github.com/Stardown-app/Stardown/blob/main/docs/troubleshooting.md" target="_blank">
         Troubleshooting and reporting bugs
       </a><br />
+      <a href="https://github.com/Stardown-app/Stardown?tab=readme-ov-file#how-to-change-the-keyboard-shortcut"
+        target="_blank">
+        How to change the keyboard shortcut
+      </a><br />
       <a href="https://github.com/Stardown-app/Stardown/discussions" target="_blank">
         Join the discussion
       </a><br />
       <a href="https://github.com/Stardown-app/Stardown?tab=readme-ov-file#feature-requests-and-alternatives"
         target="_blank">
         Request a feature
-      </a><br />
-      <a href="https://github.com/Stardown-app/Stardown?tab=readme-ov-file#how-to-change-the-keyboard-shortcut"
-        target="_blank">
-        How to change the keyboard shortcut
       </a><br />
       <a href="https://github.com/Stardown-app/Stardown" target="_blank">Source code</a>
     </p>


### PR DESCRIPTION
Fixes #110.

I'm not 100% sure it's because of these changes, but now reloading the extension sometimes makes the context menu options disappear. Reloading again usually makes them reappear; keep reloading repeatedly and they will eventually reappear. I hope this only applies when installing from source, but I will think about what might be causing this.