### PR TITLE
Attempt to fix GH Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,12 +32,8 @@ jobs:
           cp README.md LICENSE firefox
           echo "Copying docs into folder"
           cp -r docs firefox/docs
-          echo "$GITHUB_REF_NAME"
-          echo "${{ github.ref_name }}"
-          echo "stardown-$GITHUB_REF_NAME-firefox.zip"
-          echo "stardown-${{ github.ref_name }}-firefox.zip"
-          echo "Zipping folder"
-          zip -r "stardown-$GITHUB_REF_NAME-firefox.zip" firefox
+          echo "Zipping folder into stardown-${{ github.ref_name }}-firefox.zip"
+          zip -r "stardown-${{ github.ref_name }}-firefox.zip" firefox
       - name: Build for Chrome
         run: |
           npm run build-chrome
@@ -45,13 +41,13 @@ jobs:
           cp README.md LICENSE chrome
           echo "Copying docs into folder"
           cp -r docs chrome/docs
-          echo "Zipping folder"
-          zip -r "stardown-$GITHUB_REF_NAME-chrome.zip" chrome
+          echo "Zipping folder into stardown-${{ github.ref_name }}-chrome.zip"
+          zip -r "stardown-${{ github.ref_name }}-chrome.zip" chrome
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           generate_release_notes: true
           files: |
-            stardown-$GITHUB_REF_NAME-firefox.zip
-            stardown-$GITHUB_REF_NAME-chrome.zip
+            stardown-${{ github.ref_name }}-firefox.zip
+            stardown-${{ github.ref_name }}-chrome.zip


### PR DESCRIPTION
Apparently softprops/action-gh-release@v2 does not resolve $GITHUB_REF_NAME. Hopefully ${{ github.ref_name }} will work.