### PR TITLE
Remove dates from blockquote outputs

### DIFF
--- a/src/generators/md.js
+++ b/src/generators/md.js
@@ -90,11 +90,7 @@ export async function createAlert(type, text) {
 export async function createBlockquote(body, title, url) {
     body = body.trim().replaceAll("\n", "\n> ");
     const link = await createLink(title, url);
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
-    const day = now.getDate();
-    return `> ${body}\n> \n> — ${link} (${year}/${month}/${day})`;
+    return `> ${body}\n> \n> — ${link}`;
 }
 
 /**

--- a/test/md.js
+++ b/test/md.js
@@ -42,7 +42,7 @@ test("md.createBlockquote", async () => {
     const day = now.getDate();
     const expected = `> This is a test.
 > 
-> — [Example](https://example.com) (${year}/${month}/${day})
+> — [Example](https://example.com)
 `;
 
     const title = "Example";


### PR DESCRIPTION
The dates could easily be misunderstood to be when the content of the quote was written.