### PR TITLE
Fix type error on table cell with "0" or "00", etc

### DIFF
--- a/src/converters/json.js
+++ b/src/converters/json.js
@@ -169,7 +169,10 @@ export function fixLeadingZeros(numStr) {
             numStr[i] === "E"
         ) {
             return "0" + numStr.slice(i);
+        } else {
+            return numStr.slice(i);
         }
-        return numStr.slice(i);
     }
+
+    return "0";
 }


### PR DESCRIPTION
The error was `TypeError: can't access property "length", numStr is undefined`, which came from the code `if (numStr[numStr.length - 1] === ".")`. This bug was triggered when copying (as JSON) a table with at least one cell that had only zeros (one or more of them).