### PR TITLE
Fix selection ancestor table detection

### DIFF
--- a/src/htmlSelection.js
+++ b/src/htmlSelection.js
@@ -414,6 +414,7 @@ function startBeforeAncestorTable(startRange, startNode) {
     let temp = parent;
     let i = 0;
     while (
+        temp &&
         temp.nodeName !== "TABLE" &&
         (i < 10 || tableTags.includes(temp.nodeName))
     ) {


### PR DESCRIPTION
The error message was `TypeError: can't access property "nodeName", temp is null`.